### PR TITLE
feat: Added jwt authentication to weather forecast query endpoint

### DIFF
--- a/WeatherForecastChallenge.API/Controllers/AuthController.cs
+++ b/WeatherForecastChallenge.API/Controllers/AuthController.cs
@@ -1,4 +1,5 @@
 ﻿using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -13,6 +14,7 @@ namespace WeatherForecastChallenge.API.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
+    [AllowAnonymous]
     public class AuthController : MainController
     {
         private readonly IMediator _mediator;

--- a/WeatherForecastChallenge.API/Controllers/WeatherForecastController.cs
+++ b/WeatherForecastChallenge.API/Controllers/WeatherForecastController.cs
@@ -1,11 +1,12 @@
 ﻿using MediatR;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using System.Threading.Tasks;
 using WeatherForecastChallenge.Application.Query.CommandQuery;
-using WeatherForecastChallenge.Core.Entities;
 using WeatherForecastChallenge.Core.Response;
 
+
 [ApiController]
+[Authorize]
 [Route("api/[controller]")]
 public class WeatherForecastController : ControllerBase
 {
@@ -21,7 +22,7 @@ public class WeatherForecastController : ControllerBase
     /// </summary>
     /// <param name="city"></param>
     /// <returns>Weather forecast api that fetches data from WeatherAPI and returns location - temperature - humidity - weather condition - wind speed</returns>
-    [HttpGet("{city}")]
+    [HttpGet("{city}")]    
     [ProducesResponseType(typeof(WeatherApiResponse), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetWeatherForecast(string city)
     {

--- a/WeatherForecastChallenge.API/Program.cs
+++ b/WeatherForecastChallenge.API/Program.cs
@@ -10,6 +10,7 @@ using WeatherForecastChallenge.Infrastructure.Auth;
 using WeatherForecastChallenge.Application.Commands.UserCommands.Login;
 using WeatherForecastChallenge.Application.Commands.UserCommands.Register;
 using System.Net.Http.Headers;
+using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 var configuration = builder.Configuration;
@@ -54,11 +55,39 @@ builder.Services.AddAuthentication(options =>
 // Configuração do Swagger
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
-{
-    // Defina o caminho para o arquivo XML
+{    
     var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
     var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
     c.IncludeXmlComments(xmlPath);
+    
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "WeatherForecastChallenge", Version = "v1" });
+
+    // Configura a segurança JWT
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Type = SecuritySchemeType.ApiKey,
+        Scheme = "Bearer",
+        BearerFormat = "JWT",
+        In = ParameterLocation.Header,
+        Description = "Forneça o token JWT no formato 'Bearer {token}' no cabeçalho de autorização. Este token é necessário para autenticar suas requisições à API. Você pode obtê-lo ao fazer login com suas credenciais de usuário."
+    });
+
+    // Aplica a segurança a todos os endpoints
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+        {
+            {
+                new OpenApiSecurityScheme
+                {
+                    Reference = new OpenApiReference
+                    {
+                        Type = ReferenceType.SecurityScheme,
+                        Id = "Bearer"
+                    }
+                },
+                new string[] {}
+            }
+        });
 });
 
 var weatherApiKey = configuration["WeatherApi:ApiKey"];


### PR DESCRIPTION
to use the weather forecast endpoint for the current day, you need to enter the jwt token that the login api provides